### PR TITLE
feat: add 14 remote skills from rshade/agent-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ That single command gives you:
 - Multi-agent config generation with per-agent adaptations (MCP format, hook delivery, agent tools, skill frontmatter)
 - LSP support for Go, Python, TypeScript, and C# via the official marketplace
 - Session tracking that logs every tool call, blocked command, and file modification across sessions
-- 3 built-in skills (commit, PR, review) plus 32 remote skills covering Pulumi IaC, Flux CD GitOps, Go, Python, TypeScript, Kubernetes, DevOps, SRE, AGENTS.md generation, and more
+- 3 built-in skills (commit, PR, review) plus 46 remote skills covering Pulumi IaC, Flux CD GitOps, Go, Python, TypeScript, Kubernetes, DevOps, SRE, security auditing, code quality, tech debt analysis, and more
 - 12 agents: 3 built-in (executor, librarian, reviewer) plus 9 remote agents from [agency-agents](https://github.com/msitarzewski/agency-agents) covering AI engineering, backend architecture, security, code review, DevOps, SRE, and testing
 - Plugin support with marketplace auto-enablement — ships with [OpenAI Codex](https://github.com/openai/codex-plugin-cc) for code review and task delegation
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -260,7 +260,7 @@ The ref can be a tag, branch, or commit SHA. Skills are cached in `~/.yaah/cache
 
 ### Default remote skills
 
-yaah ships 32 remote skills from six repos:
+yaah ships 46 remote skills from seven repos:
 
 **pulumi/agent-skills** -- Pulumi IaC authoring and migration:
 
@@ -329,6 +329,25 @@ yaah ships 32 remote skills from six repos:
 | ------------- | -------------------------------------------------------------------- |
 | `agent-rules` | Generate and maintain AGENTS.md files following agents.md convention |
 
+**rshade/agent-skills** -- Code quality, security, and workflow automation:
+
+| Skill                | Description                                                         |
+| -------------------- | ------------------------------------------------------------------- |
+| `agent-ready-go`     | Prepare Go apps for AI agent interaction                            |
+| `commitlint`         | Validate commit messages against Conventional Commits               |
+| `decide`             | Three-agent adversarial debate for strategic decisions              |
+| `dep-upgrade`        | Safe systematic dependency upgrades with rollback                   |
+| `design-principles`  | Analyze codebases against SOLID, DRY, YAGNI, KISS                  |
+| `go-nolint-audit`    | Audit nolint directives in Go codebases                             |
+| `lint-fix`           | Detect linting tools and fix issues atomically                      |
+| `markdownlint`       | Validate markdown formatting with auto-fix                          |
+| `pull-request-msg`   | Generate structured PR descriptions via GitHub CLI                  |
+| `roadmap`            | Strategic roadmap management synced with GitHub Issues               |
+| `scout`              | Identify top improvement opportunities in touched files             |
+| `security-audit`     | Comprehensive vulnerability assessment with OWASP and STRIDE        |
+| `tailscale-install`  | Install and configure Tailscale across platforms                    |
+| `tech-debt`          | Systematic technical debt analysis with health scoring              |
+
 ### Skill catalog
 
 yaah maintains a catalog of all available skills in `pkg/catalog/`. The catalog provides discovery, search, and categorization without needing to edit Go code.
@@ -365,14 +384,15 @@ Bundles group skills by role or use case:
 
 | Bundle             | Skills | Description                          |
 | ------------------ | ------ | ------------------------------------ |
-| `go-dev`           | 3      | Full Go development stack            |
+| `go-dev`           | 5      | Full Go development stack            |
 | `pulumi-core`      | 5      | Essential Pulumi IaC skills          |
 | `pulumi-migration` | 4      | Cloud migration toolkit              |
 | `pulumi-languages` | 5      | Pulumi language-specific IaC         |
-| `security`         | 3      | Security-focused review and analysis |
+| `security`         | 4      | Security-focused review and analysis |
 | `full-stack`       | 5      | Full-stack web development languages |
 | `devops`           | 5      | Infrastructure and operations        |
 | `rust`             | 3      | Rust ecosystem skills                |
+| `code-quality`     | 7      | Linting, auditing, and improvement   |
 | `architecture`     | 3      | System design and critical thinking  |
 
 ### Skill metadata

--- a/pkg/catalog/entries.go
+++ b/pkg/catalog/entries.go
@@ -8,6 +8,7 @@ const (
 	apolloSkillsRef          = "github.com/apollographql/skills@e1979d2f1e7c38cef58753b2bfd6fc9509101bdc"
 	wshobsonAgentsRef        = "github.com/wshobson/agents@1ad2f007d5e9ec822a2d79e727ac1dcdf5f66f11"
 	netresearchAgentRulesRef = "github.com/netresearch/agent-rules-skill@96cde6c491d854c89ad419b1ba543fa6545748aa"
+	rshadeAgentSkillsRef    = "github.com/rshade/agent-skills@4aff11fe89bb156337c2c7c303bb2db234cc9740"
 )
 
 // DefaultCatalog returns the complete catalog of all built-in and remote skills with bundles.
@@ -317,6 +318,120 @@ func defaultSkills() []CatalogEntry {
 			Uses: netresearchAgentRulesRef, Subpath: "skills/agent-rules/SKILL.md",
 			Repo: "netresearch/agent-rules-skill",
 		},
+
+		// rshade/agent-skills — Code quality, security, and workflow automation.
+		{
+			ID: "agent-ready-go", Name: "agent-ready-go",
+			Description: "Prepare Go apps for AI agent interaction with structured logging and CLI design",
+			Category:    CategoryLanguage, Tags: []string{"go", "agent-ready", "logging", "cli"},
+			Risk: RiskSafe, Tier: TierVerified,
+			Uses: rshadeAgentSkillsRef, Subpath: "skills/agent-ready-go/SKILL.md",
+			Repo: "rshade/agent-skills",
+		},
+		{
+			ID: "commitlint", Name: "commitlint",
+			Description: "Validate commit messages against Conventional Commits specification",
+			Category:    CategoryWorkflow, Tags: []string{"git", "commits", "linting", "conventional-commits"},
+			Risk: RiskSafe, Tier: TierVerified,
+			Uses: rshadeAgentSkillsRef, Subpath: "skills/commitlint/SKILL.md",
+			Repo: "rshade/agent-skills",
+		},
+		{
+			ID: "decide", Name: "decide",
+			Description: "Three-agent adversarial debate protocol for strategic decisions",
+			Category:    CategoryArchitecture, Tags: []string{"decision-making", "debate", "tradeoffs"},
+			Risk: RiskSafe, Tier: TierVerified,
+			Uses: rshadeAgentSkillsRef, Subpath: "skills/decide/SKILL.md",
+			Repo: "rshade/agent-skills",
+		},
+		{
+			ID: "dep-upgrade", Name: "dep-upgrade",
+			Description: "Safe systematic dependency upgrades with vulnerability scanning and rollback",
+			Category:    CategoryWorkflow, Tags: []string{"dependencies", "upgrades", "security", "vulnerability"},
+			Risk: RiskCritical, Tier: TierVerified,
+			Uses: rshadeAgentSkillsRef, Subpath: "skills/dep-upgrade/SKILL.md",
+			Repo: "rshade/agent-skills",
+		},
+		{
+			ID: "design-principles", Name: "design-principles",
+			Description: "Analyze codebases against SOLID, DRY, YAGNI, KISS, and other design principles",
+			Category:    CategoryArchitecture, Tags: []string{"design", "solid", "code-quality", "audit"},
+			Risk: RiskSafe, Tier: TierVerified,
+			Uses: rshadeAgentSkillsRef, Subpath: "skills/design-principles/SKILL.md",
+			Repo: "rshade/agent-skills",
+		},
+		{
+			ID: "go-nolint-audit", Name: "go-nolint-audit",
+			Description: "Audit nolint directives in Go codebases for stale or unjustified suppressions",
+			Category:    CategoryLanguage, Tags: []string{"go", "linting", "nolint", "audit"},
+			Risk: RiskSafe, Tier: TierVerified,
+			Uses: rshadeAgentSkillsRef, Subpath: "skills/go-nolint-audit/SKILL.md",
+			Repo: "rshade/agent-skills",
+		},
+		{
+			ID: "lint-fix", Name: "lint-fix",
+			Description: "Detect linting tools, run them to zero errors, and fix issues atomically",
+			Category:    CategoryWorkflow, Tags: []string{"linting", "fixing", "code-quality"},
+			Risk: RiskCritical, Tier: TierVerified,
+			Uses: rshadeAgentSkillsRef, Subpath: "skills/lint-fix/SKILL.md",
+			Repo: "rshade/agent-skills",
+		},
+		{
+			ID: "markdownlint", Name: "markdownlint",
+			Description: "Validate markdown files against formatting standards with auto-fix",
+			Category:    CategoryWorkflow, Tags: []string{"markdown", "linting", "documentation"},
+			Risk: RiskSafe, Tier: TierVerified,
+			Uses: rshadeAgentSkillsRef, Subpath: "skills/markdownlint/SKILL.md",
+			Repo: "rshade/agent-skills",
+		},
+		{
+			ID: "pull-request-msg", Name: "pull-request-msg",
+			Description: "Generate structured PR descriptions from session context using GitHub CLI",
+			Category:    CategoryWorkflow, Tags: []string{"github", "pull-request", "automation"},
+			Risk: RiskSafe, Tier: TierVerified,
+			Uses: rshadeAgentSkillsRef, Subpath: "skills/pull-request-msg-with-gh/SKILL.md",
+			Repo: "rshade/agent-skills",
+		},
+		{
+			ID: "roadmap", Name: "roadmap",
+			Description: "Strategic roadmap management synced with GitHub Issues and labels",
+			Category:    CategoryWorkflow, Tags: []string{"roadmap", "planning", "github", "issues"},
+			Risk: RiskCritical, Tier: TierVerified,
+			Uses: rshadeAgentSkillsRef, Subpath: "skills/roadmap/SKILL.md",
+			Repo: "rshade/agent-skills",
+		},
+		{
+			ID: "scout", Name: "scout",
+			Description: "Identify top improvement opportunities in files you are touching",
+			Category:    CategoryWorkflow, Tags: []string{"code-quality", "improvement", "review"},
+			Risk: RiskSafe, Tier: TierVerified,
+			Uses: rshadeAgentSkillsRef, Subpath: "skills/scout/SKILL.md",
+			Repo: "rshade/agent-skills",
+		},
+		{
+			ID: "security-audit", Name: "security-audit",
+			Description: "Comprehensive vulnerability assessment with OWASP Top 10 and threat modeling",
+			Category:    CategorySecurity, Tags: []string{"security", "owasp", "vulnerability", "audit"},
+			Risk: RiskSafe, Tier: TierVerified,
+			Uses: rshadeAgentSkillsRef, Subpath: "skills/security-audit/SKILL.md",
+			Repo: "rshade/agent-skills",
+		},
+		{
+			ID: "tailscale-install", Name: "tailscale-install",
+			Description: "Install and configure Tailscale across platforms including WSL2 and containers",
+			Category:    CategoryInfrastructure, Tags: []string{"tailscale", "vpn", "networking", "install"},
+			Risk: RiskCritical, Tier: TierVerified,
+			Uses: rshadeAgentSkillsRef, Subpath: "skills/tailscale-install/SKILL.md",
+			Repo: "rshade/agent-skills",
+		},
+		{
+			ID: "tech-debt", Name: "tech-debt",
+			Description: "Systematic technical debt analysis across 9 categories with health scoring",
+			Category:    CategoryArchitecture, Tags: []string{"tech-debt", "audit", "code-quality", "architecture"},
+			Risk: RiskSafe, Tier: TierVerified,
+			Uses: rshadeAgentSkillsRef, Subpath: "skills/tech-debt/SKILL.md",
+			Repo: "rshade/agent-skills",
+		},
 	}
 }
 
@@ -325,7 +440,7 @@ func defaultBundles() []Bundle {
 		{
 			ID: "go-dev", Name: "Go Development",
 			Description: "Full Go development stack",
-			SkillIDs:    []string{"golang-pro", "pulumi-go", "cli-developer"},
+			SkillIDs:    []string{"golang-pro", "pulumi-go", "cli-developer", "agent-ready-go", "go-nolint-audit"},
 		},
 		{
 			ID: "pulumi-core", Name: "Pulumi Core",
@@ -345,7 +460,7 @@ func defaultBundles() []Bundle {
 		{
 			ID: "security", Name: "Security",
 			Description: "Security-focused review and analysis skills",
-			SkillIDs:    []string{"review", "code-reviewer", "the-fool"},
+			SkillIDs:    []string{"review", "code-reviewer", "the-fool", "security-audit"},
 		},
 		{
 			ID: "full-stack", Name: "Full Stack",
@@ -361,6 +476,11 @@ func defaultBundles() []Bundle {
 			ID: "rust", Name: "Rust Development",
 			Description: "Rust ecosystem skills",
 			SkillIDs:    []string{"rust-best-practices", "rust-async-patterns", "rust-engineer"},
+		},
+		{
+			ID: "code-quality", Name: "Code Quality",
+			Description: "Linting, auditing, and code improvement skills",
+			SkillIDs:    []string{"lint-fix", "commitlint", "markdownlint", "scout", "design-principles", "tech-debt", "dep-upgrade"},
 		},
 		{
 			ID: "architecture", Name: "Architecture",

--- a/pkg/harness/defaults.go
+++ b/pkg/harness/defaults.go
@@ -80,6 +80,22 @@ type DefaultOptions struct {
 	// Remote skills — netresearch/agent-rules-skill
 	EnableAgentRules bool
 
+	// Remote skills — rshade/agent-skills
+	EnableAgentReadyGo    bool
+	EnableCommitlint      bool
+	EnableDecide          bool
+	EnableDepUpgrade      bool
+	EnableDesignPrinciples bool
+	EnableGoNolintAudit   bool
+	EnableLintFix         bool
+	EnableMarkdownlint    bool
+	EnablePullRequestMsg  bool
+	EnableRoadmap         bool
+	EnableScout           bool
+	EnableSecurityAudit   bool
+	EnableTailscaleInstall bool
+	EnableTechDebt        bool
+
 	// Catalog-based skill selection (overrides individual Enable* flags for skills when set).
 	SkillIDs   []string // Register only these skills from the catalog.
 	BundleIDs  []string // Resolve bundles and register their skills.
@@ -168,6 +184,20 @@ func AllDefaults() DefaultOptions {
 		EnableRustAsyncPatterns:            true,
 		EnableRustEngineer:                 true,
 		EnableAgentRules:                   true,
+		EnableAgentReadyGo:                true,
+		EnableCommitlint:                  true,
+		EnableDecide:                      true,
+		EnableDepUpgrade:                  true,
+		EnableDesignPrinciples:            true,
+		EnableGoNolintAudit:               true,
+		EnableLintFix:                     true,
+		EnableMarkdownlint:                true,
+		EnablePullRequestMsg:              true,
+		EnableRoadmap:                     true,
+		EnableScout:                       true,
+		EnableSecurityAudit:               true,
+		EnableTailscaleInstall:            true,
+		EnableTechDebt:                    true,
 		EnableCodexPlugin:                 true,
 		EnableGopls:                        true,
 		EnablePyright:                      true,
@@ -455,6 +485,93 @@ func NewWithDefaults(opts DefaultOptions) *Harness {
 		p.Skills().Register(skills.NewRemoteSkill(
 			"agent-rules", "Generate and maintain AGENTS.md files following the agents.md convention",
 			"github.com/netresearch/agent-rules-skill@96cde6c491d854c89ad419b1ba543fa6545748aa", "skills/agent-rules/SKILL.md",
+		))
+	}
+
+	// Remote skills — rshade/agent-skills
+	const rshadeRef = "github.com/rshade/agent-skills@4aff11fe89bb156337c2c7c303bb2db234cc9740"
+	if opts.EnableAgentReadyGo {
+		p.Skills().Register(skills.NewRemoteSkill(
+			"agent-ready-go", "Prepare Go apps for AI agent interaction with structured logging and CLI design",
+			rshadeRef, "skills/agent-ready-go/SKILL.md",
+		))
+	}
+	if opts.EnableCommitlint {
+		p.Skills().Register(skills.NewRemoteSkill(
+			"commitlint", "Validate commit messages against Conventional Commits specification",
+			rshadeRef, "skills/commitlint/SKILL.md",
+		))
+	}
+	if opts.EnableDecide {
+		p.Skills().Register(skills.NewRemoteSkill(
+			"decide", "Three-agent adversarial debate protocol for strategic decisions",
+			rshadeRef, "skills/decide/SKILL.md",
+		))
+	}
+	if opts.EnableDepUpgrade {
+		p.Skills().Register(skills.NewRemoteSkill(
+			"dep-upgrade", "Safe systematic dependency upgrades with vulnerability scanning and rollback",
+			rshadeRef, "skills/dep-upgrade/SKILL.md",
+		))
+	}
+	if opts.EnableDesignPrinciples {
+		p.Skills().Register(skills.NewRemoteSkill(
+			"design-principles", "Analyze codebases against SOLID, DRY, YAGNI, KISS, and other design principles",
+			rshadeRef, "skills/design-principles/SKILL.md",
+		))
+	}
+	if opts.EnableGoNolintAudit {
+		p.Skills().Register(skills.NewRemoteSkill(
+			"go-nolint-audit", "Audit nolint directives in Go codebases for stale or unjustified suppressions",
+			rshadeRef, "skills/go-nolint-audit/SKILL.md",
+		))
+	}
+	if opts.EnableLintFix {
+		p.Skills().Register(skills.NewRemoteSkill(
+			"lint-fix", "Detect linting tools, run them to zero errors, and fix issues atomically",
+			rshadeRef, "skills/lint-fix/SKILL.md",
+		))
+	}
+	if opts.EnableMarkdownlint {
+		p.Skills().Register(skills.NewRemoteSkill(
+			"markdownlint", "Validate markdown files against formatting standards with auto-fix",
+			rshadeRef, "skills/markdownlint/SKILL.md",
+		))
+	}
+	if opts.EnablePullRequestMsg {
+		p.Skills().Register(skills.NewRemoteSkill(
+			"pull-request-msg", "Generate structured PR descriptions from session context using GitHub CLI",
+			rshadeRef, "skills/pull-request-msg-with-gh/SKILL.md",
+		))
+	}
+	if opts.EnableRoadmap {
+		p.Skills().Register(skills.NewRemoteSkill(
+			"roadmap", "Strategic roadmap management synced with GitHub Issues and labels",
+			rshadeRef, "skills/roadmap/SKILL.md",
+		))
+	}
+	if opts.EnableScout {
+		p.Skills().Register(skills.NewRemoteSkill(
+			"scout", "Identify top improvement opportunities in files you are touching",
+			rshadeRef, "skills/scout/SKILL.md",
+		))
+	}
+	if opts.EnableSecurityAudit {
+		p.Skills().Register(skills.NewRemoteSkill(
+			"security-audit", "Comprehensive vulnerability assessment with OWASP Top 10 and threat modeling",
+			rshadeRef, "skills/security-audit/SKILL.md",
+		))
+	}
+	if opts.EnableTailscaleInstall {
+		p.Skills().Register(skills.NewRemoteSkill(
+			"tailscale-install", "Install and configure Tailscale across platforms including WSL2 and containers",
+			rshadeRef, "skills/tailscale-install/SKILL.md",
+		))
+	}
+	if opts.EnableTechDebt {
+		p.Skills().Register(skills.NewRemoteSkill(
+			"tech-debt", "Systematic technical debt analysis across 9 categories with health scoring",
+			rshadeRef, "skills/tech-debt/SKILL.md",
 		))
 	}
 

--- a/website/index.html
+++ b/website/index.html
@@ -83,7 +83,7 @@
           <div><span class="prompt">$</span> <span class="cmd">yaah generate</span></div>
           <div><span class="output">&nbsp;</span></div>
           <div><span class="success">&#10004;</span> <span class="output">Generated</span> <span class="file">.claude/settings.json</span></div>
-          <div><span class="success">&#10004;</span> <span class="output">Generated</span> <span class="file">.claude/skills/</span> <span class="output">(35 skills)</span></div>
+          <div><span class="success">&#10004;</span> <span class="output">Generated</span> <span class="file">.claude/skills/</span> <span class="output">(49 skills)</span></div>
           <div><span class="success">&#10004;</span> <span class="output">Generated</span> <span class="file">.claude/agents/</span> <span class="output">(12 agents)</span></div>
           <div><span class="success">&#10004;</span> <span class="output">Generated</span> <span class="file">.mcp.json</span> <span class="output">(3 servers)</span></div>
           <div><span class="success">&#10004;</span> <span class="output">Generated</span> <span class="file">opencode.json</span></div>
@@ -100,7 +100,7 @@
           <div class="stat-label">Agents</div>
         </div>
         <div class="stat">
-          <div class="stat-value">35</div>
+          <div class="stat-value">49</div>
           <div class="stat-label">Skills</div>
         </div>
         <div class="stat">
@@ -175,7 +175,7 @@
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#00d4aa" stroke-width="2"><path d="M4 19.5A2.5 2.5 0 016.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 014 19.5v-15A2.5 2.5 0 016.5 2z"/></svg>
           </div>
           <h3>Skill Catalog</h3>
-          <p>35 skills organized by category, tags, risk level, and bundles. Search, filter, and discover skills via <code>yaah skills</code> CLI. Extend with external registries.</p>
+          <p>49 skills organized by category, tags, risk level, and bundles. Search, filter, and discover skills via <code>yaah skills</code> CLI. Extend with external registries.</p>
         </div>
 
         <div class="feature-card fade-in">


### PR DESCRIPTION
## Summary
- Add 14 remote skills from [rshade/agent-skills](https://github.com/rshade/agent-skills) pinned to `4aff11f`
- New skills: agent-ready-go, commitlint, decide, dep-upgrade, design-principles, go-nolint-audit, lint-fix, markdownlint, pull-request-msg, roadmap, scout, security-audit, tailscale-install, tech-debt
- Add new `code-quality` bundle (7 skills)
- Update `go-dev` bundle (3→5) and `security` bundle (3→4)
- Update skill counts: 46 remote, 49 total (README, docs, website)

## Test plan
- [x] `go build -v ./...` passes
- [x] `go vet ./...` clean
- [x] `go test -race -short ./pkg/catalog/... ./pkg/harness/...` passes