### PR TITLE
chore: sync remote skills to latest versions

### DIFF
--- a/pkg/catalog/entries.go
+++ b/pkg/catalog/entries.go
@@ -2,12 +2,12 @@ package catalog
 
 const (
 	// Remote refs pinned to specific commits.
-	pulumiAgentSkillsRef     = "github.com/pulumi/agent-skills@fbeac07327a601b954ba82e7f7e1c24cf3b1fa71"
+	pulumiAgentSkillsRef     = "github.com/pulumi/agent-skills@f810e5000b5881ec41ea9c33c001ac8c25cbd2f2"
 	dirienClaudeSkillsRef    = "github.com/dirien/claude-skills@22aaf94d59d53c88a5465bcb5434d309fae8787a"
-	jeffallanClaudeSkillsRef = "github.com/jeffallan/claude-skills@5b761018cebd430edcecbeeb46bdde6150d22c65"
-	apolloSkillsRef          = "github.com/apollographql/skills@ad83e824c65465b81898622f5f33c0aa1c1b187a"
-	wshobsonAgentsRef        = "github.com/wshobson/agents@87b81e9d642d7bb9602b33d1e2dadf1c2a619f2b"
-	netresearchAgentRulesRef = "github.com/netresearch/agent-rules-skill@9b67bf594a52b1a7d38d8b0ec0a076a31f8d3d7e"
+	jeffallanClaudeSkillsRef = "github.com/jeffallan/claude-skills@e8be415bc94d8d6ebddc2fb50e5d03c6e27d4319"
+	apolloSkillsRef          = "github.com/apollographql/skills@64d4087d629e413da1bac780abeaefd653847440"
+	wshobsonAgentsRef        = "github.com/wshobson/agents@4bb47e9eeb4e8564642eb23384ec8f7bf1855417"
+	netresearchAgentRulesRef = "github.com/netresearch/agent-rules-skill@c8196b1bb9821ca3950639263af6d44cadf6caa1"
 	rshadeAgentSkillsRef     = "github.com/rshade/agent-skills@202393300c0d22a6a10c93a2fa46e33ac54238a3"
 )
 

--- a/pkg/harness/defaults.go
+++ b/pkg/harness/defaults.go
@@ -450,49 +450,49 @@ func NewWithDefaults(opts DefaultOptions) *Harness {
 	if opts.EnablePulumiBestPractices {
 		p.Skills().Register(skills.NewRemoteSkill(
 			"pulumi-best-practices", "Pulumi best practices for reliable programs",
-			"github.com/pulumi/agent-skills@fbeac07327a601b954ba82e7f7e1c24cf3b1fa71", "authoring/skills/pulumi-best-practices/SKILL.md",
+			"github.com/pulumi/agent-skills@f810e5000b5881ec41ea9c33c001ac8c25cbd2f2", "authoring/skills/pulumi-best-practices/SKILL.md",
 		))
 	}
 	if opts.EnablePulumiComponent {
 		p.Skills().Register(skills.NewRemoteSkill(
 			"pulumi-component", "Pulumi ComponentResource authoring",
-			"github.com/pulumi/agent-skills@fbeac07327a601b954ba82e7f7e1c24cf3b1fa71", "authoring/skills/pulumi-component/SKILL.md",
+			"github.com/pulumi/agent-skills@f810e5000b5881ec41ea9c33c001ac8c25cbd2f2", "authoring/skills/pulumi-component/SKILL.md",
 		))
 	}
 	if opts.EnablePulumiAutomationAPI {
 		p.Skills().Register(skills.NewRemoteSkill(
 			"pulumi-automation-api", "Pulumi Automation API best practices",
-			"github.com/pulumi/agent-skills@fbeac07327a601b954ba82e7f7e1c24cf3b1fa71", "authoring/skills/pulumi-automation-api/SKILL.md",
+			"github.com/pulumi/agent-skills@f810e5000b5881ec41ea9c33c001ac8c25cbd2f2", "authoring/skills/pulumi-automation-api/SKILL.md",
 		))
 	}
 	if opts.EnablePulumiESC {
 		p.Skills().Register(skills.NewRemoteSkill(
 			"pulumi-esc", "Pulumi ESC environments, secrets, and configuration",
-			"github.com/pulumi/agent-skills@fbeac07327a601b954ba82e7f7e1c24cf3b1fa71", "authoring/skills/pulumi-esc/SKILL.md",
+			"github.com/pulumi/agent-skills@f810e5000b5881ec41ea9c33c001ac8c25cbd2f2", "authoring/skills/pulumi-esc/SKILL.md",
 		))
 	}
 	if opts.EnablePulumiTerraformMigrate {
 		p.Skills().Register(skills.NewRemoteSkill(
 			"pulumi-terraform-to-pulumi", "Convert Terraform to Pulumi",
-			"github.com/pulumi/agent-skills@fbeac07327a601b954ba82e7f7e1c24cf3b1fa71", "migration/skills/pulumi-terraform-to-pulumi/SKILL.md",
+			"github.com/pulumi/agent-skills@f810e5000b5881ec41ea9c33c001ac8c25cbd2f2", "migration/skills/pulumi-terraform-to-pulumi/SKILL.md",
 		))
 	}
 	if opts.EnablePulumiCDKMigrate {
 		p.Skills().Register(skills.NewRemoteSkill(
 			"pulumi-cdk-to-pulumi", "Convert AWS CDK to Pulumi",
-			"github.com/pulumi/agent-skills@fbeac07327a601b954ba82e7f7e1c24cf3b1fa71", "migration/skills/pulumi-cdk-to-pulumi/SKILL.md",
+			"github.com/pulumi/agent-skills@f810e5000b5881ec41ea9c33c001ac8c25cbd2f2", "migration/skills/pulumi-cdk-to-pulumi/SKILL.md",
 		))
 	}
 	if opts.EnablePulumiCFNMigrate {
 		p.Skills().Register(skills.NewRemoteSkill(
 			"cloudformation-to-pulumi", "Convert CloudFormation to Pulumi",
-			"github.com/pulumi/agent-skills@fbeac07327a601b954ba82e7f7e1c24cf3b1fa71", "migration/skills/cloudformation-to-pulumi/SKILL.md",
+			"github.com/pulumi/agent-skills@f810e5000b5881ec41ea9c33c001ac8c25cbd2f2", "migration/skills/cloudformation-to-pulumi/SKILL.md",
 		))
 	}
 	if opts.EnablePulumiARMMigrate {
 		p.Skills().Register(skills.NewRemoteSkill(
 			"pulumi-arm-to-pulumi", "Convert Azure ARM/Bicep to Pulumi",
-			"github.com/pulumi/agent-skills@fbeac07327a601b954ba82e7f7e1c24cf3b1fa71", "migration/skills/pulumi-arm-to-pulumi/SKILL.md",
+			"github.com/pulumi/agent-skills@f810e5000b5881ec41ea9c33c001ac8c25cbd2f2", "migration/skills/pulumi-arm-to-pulumi/SKILL.md",
 		))
 	}
 
@@ -544,79 +544,79 @@ func NewWithDefaults(opts DefaultOptions) *Harness {
 	if opts.EnableGolangPro {
 		p.Skills().Register(skills.NewRemoteSkill(
 			"golang-pro", "Go concurrent patterns, microservices, gRPC, and performance optimization",
-			"github.com/jeffallan/claude-skills@5b761018cebd430edcecbeeb46bdde6150d22c65", "skills/golang-pro/SKILL.md",
+			"github.com/jeffallan/claude-skills@e8be415bc94d8d6ebddc2fb50e5d03c6e27d4319", "skills/golang-pro/SKILL.md",
 		))
 	}
 	if opts.EnableKubernetesSpecialist {
 		p.Skills().Register(skills.NewRemoteSkill(
 			"kubernetes-specialist", "Kubernetes deployments, Helm, RBAC, NetworkPolicies, and multi-cluster",
-			"github.com/jeffallan/claude-skills@5b761018cebd430edcecbeeb46bdde6150d22c65", "skills/kubernetes-specialist/SKILL.md",
+			"github.com/jeffallan/claude-skills@e8be415bc94d8d6ebddc2fb50e5d03c6e27d4319", "skills/kubernetes-specialist/SKILL.md",
 		))
 	}
 	if opts.EnableDevOpsEngineer {
 		p.Skills().Register(skills.NewRemoteSkill(
 			"devops-engineer", "CI/CD pipelines, Docker, Kubernetes, Terraform, and GitOps",
-			"github.com/jeffallan/claude-skills@5b761018cebd430edcecbeeb46bdde6150d22c65", "skills/devops-engineer/SKILL.md",
+			"github.com/jeffallan/claude-skills@e8be415bc94d8d6ebddc2fb50e5d03c6e27d4319", "skills/devops-engineer/SKILL.md",
 		))
 	}
 	if opts.EnablePythonPro {
 		p.Skills().Register(skills.NewRemoteSkill(
 			"python-pro", "Python 3.11+ with type safety, async, pytest, and ruff",
-			"github.com/jeffallan/claude-skills@5b761018cebd430edcecbeeb46bdde6150d22c65", "skills/python-pro/SKILL.md",
+			"github.com/jeffallan/claude-skills@e8be415bc94d8d6ebddc2fb50e5d03c6e27d4319", "skills/python-pro/SKILL.md",
 		))
 	}
 	if opts.EnableTypeScriptPro {
 		p.Skills().Register(skills.NewRemoteSkill(
 			"typescript-pro", "Advanced TypeScript types, generics, tRPC, and monorepo setup",
-			"github.com/jeffallan/claude-skills@5b761018cebd430edcecbeeb46bdde6150d22c65", "skills/typescript-pro/SKILL.md",
+			"github.com/jeffallan/claude-skills@e8be415bc94d8d6ebddc2fb50e5d03c6e27d4319", "skills/typescript-pro/SKILL.md",
 		))
 	}
 	if opts.EnableCSharpDeveloper {
 		p.Skills().Register(skills.NewRemoteSkill(
 			"csharp-developer", "C# .NET 8+, ASP.NET Core, Blazor, EF Core, and MediatR",
-			"github.com/jeffallan/claude-skills@5b761018cebd430edcecbeeb46bdde6150d22c65", "skills/csharp-developer/SKILL.md",
+			"github.com/jeffallan/claude-skills@e8be415bc94d8d6ebddc2fb50e5d03c6e27d4319", "skills/csharp-developer/SKILL.md",
 		))
 	}
 	if opts.EnableJavaScriptPro {
 		p.Skills().Register(skills.NewRemoteSkill(
 			"javascript-pro", "Modern ES2023+ JavaScript, async/await, ESM, and Node.js",
-			"github.com/jeffallan/claude-skills@5b761018cebd430edcecbeeb46bdde6150d22c65", "skills/javascript-pro/SKILL.md",
+			"github.com/jeffallan/claude-skills@e8be415bc94d8d6ebddc2fb50e5d03c6e27d4319", "skills/javascript-pro/SKILL.md",
 		))
 	}
 	if opts.EnableCLIDeveloper {
 		p.Skills().Register(skills.NewRemoteSkill(
 			"cli-developer", "CLI tools with argument parsing, completions, and cross-platform support",
-			"github.com/jeffallan/claude-skills@5b761018cebd430edcecbeeb46bdde6150d22c65", "skills/cli-developer/SKILL.md",
+			"github.com/jeffallan/claude-skills@e8be415bc94d8d6ebddc2fb50e5d03c6e27d4319", "skills/cli-developer/SKILL.md",
 		))
 	}
 	if opts.EnableSREEngineer {
 		p.Skills().Register(skills.NewRemoteSkill(
 			"sre-engineer", "SLOs, error budgets, incident response, and capacity planning",
-			"github.com/jeffallan/claude-skills@5b761018cebd430edcecbeeb46bdde6150d22c65", "skills/sre-engineer/SKILL.md",
+			"github.com/jeffallan/claude-skills@e8be415bc94d8d6ebddc2fb50e5d03c6e27d4319", "skills/sre-engineer/SKILL.md",
 		))
 	}
 	if opts.EnableTheFool {
 		p.Skills().Register(skills.NewRemoteSkill(
 			"the-fool", "Devil's advocate, pre-mortems, red teaming, and assumption auditing",
-			"github.com/jeffallan/claude-skills@5b761018cebd430edcecbeeb46bdde6150d22c65", "skills/the-fool/SKILL.md",
+			"github.com/jeffallan/claude-skills@e8be415bc94d8d6ebddc2fb50e5d03c6e27d4319", "skills/the-fool/SKILL.md",
 		))
 	}
 	if opts.EnableArchitectureDesigner {
 		p.Skills().Register(skills.NewRemoteSkill(
 			"architecture-designer", "System architecture, ADRs, trade-offs, and scalability planning",
-			"github.com/jeffallan/claude-skills@5b761018cebd430edcecbeeb46bdde6150d22c65", "skills/architecture-designer/SKILL.md",
+			"github.com/jeffallan/claude-skills@e8be415bc94d8d6ebddc2fb50e5d03c6e27d4319", "skills/architecture-designer/SKILL.md",
 		))
 	}
 	if opts.EnableSpringBootEngineer {
 		p.Skills().Register(skills.NewRemoteSkill(
 			"spring-boot-engineer", "Spring Boot 3.x, Spring Security 6, JPA, WebFlux, and Spring Cloud",
-			"github.com/jeffallan/claude-skills@5b761018cebd430edcecbeeb46bdde6150d22c65", "skills/spring-boot-engineer/SKILL.md",
+			"github.com/jeffallan/claude-skills@e8be415bc94d8d6ebddc2fb50e5d03c6e27d4319", "skills/spring-boot-engineer/SKILL.md",
 		))
 	}
 	if opts.EnableCodeReviewer {
 		p.Skills().Register(skills.NewRemoteSkill(
 			"code-reviewer", "Code review for bugs, security, performance, and maintainability",
-			"github.com/jeffallan/claude-skills@5b761018cebd430edcecbeeb46bdde6150d22c65", "skills/code-reviewer/SKILL.md",
+			"github.com/jeffallan/claude-skills@e8be415bc94d8d6ebddc2fb50e5d03c6e27d4319", "skills/code-reviewer/SKILL.md",
 		))
 	}
 
@@ -624,19 +624,19 @@ func NewWithDefaults(opts DefaultOptions) *Harness {
 	if opts.EnableRustBestPractices {
 		p.Skills().Register(skills.NewRemoteSkill(
 			"rust-best-practices", "Idiomatic Rust code, borrowing, error handling, and performance optimization",
-			"github.com/apollographql/skills@ad83e824c65465b81898622f5f33c0aa1c1b187a", "skills/rust-best-practices/SKILL.md",
+			"github.com/apollographql/skills@64d4087d629e413da1bac780abeaefd653847440", "skills/rust-best-practices/SKILL.md",
 		))
 	}
 	if opts.EnableRustAsyncPatterns {
 		p.Skills().Register(skills.NewRemoteSkill(
 			"rust-async-patterns", "Rust async programming with Tokio, async traits, and concurrent patterns",
-			"github.com/wshobson/agents@87b81e9d642d7bb9602b33d1e2dadf1c2a619f2b", "plugins/systems-programming/skills/rust-async-patterns/SKILL.md",
+			"github.com/wshobson/agents@4bb47e9eeb4e8564642eb23384ec8f7bf1855417", "plugins/systems-programming/skills/rust-async-patterns/SKILL.md",
 		))
 	}
 	if opts.EnableRustEngineer {
 		p.Skills().Register(skills.NewRemoteSkill(
 			"rust-engineer", "Idiomatic Rust with ownership, lifetimes, traits, tokio, and error handling",
-			"github.com/jeffallan/claude-skills@5b761018cebd430edcecbeeb46bdde6150d22c65", "skills/rust-engineer/SKILL.md",
+			"github.com/jeffallan/claude-skills@e8be415bc94d8d6ebddc2fb50e5d03c6e27d4319", "skills/rust-engineer/SKILL.md",
 		))
 	}
 
@@ -644,7 +644,7 @@ func NewWithDefaults(opts DefaultOptions) *Harness {
 	if opts.EnableAgentRules {
 		p.Skills().Register(skills.NewRemoteSkill(
 			"agent-rules", "Generate and maintain AGENTS.md files following the agents.md convention",
-			"github.com/netresearch/agent-rules-skill@9b67bf594a52b1a7d38d8b0ec0a076a31f8d3d7e", "skills/agent-rules/SKILL.md",
+			"github.com/netresearch/agent-rules-skill@c8196b1bb9821ca3950639263af6d44cadf6caa1", "skills/agent-rules/SKILL.md",
 		))
 	}
 


### PR DESCRIPTION
## Summary
- Bump 5 of 8 remote skill source pins to their latest upstream commits
- `dirien/claude-skills`, `rshade/agent-skills`, and `msitarzewski/agency-agents` are unchanged
- No behavior, interface, or documentation changes — pure pin refresh

### Updated refs
| Source | Old | New |
|--------|-----|-----|
| pulumi/agent-skills | `fbeac07` | `f810e50` |
| jeffallan/claude-skills | `5b76101` | `e8be415` |
| apollographql/skills | `ad83e82` | `64d4087` |
| wshobson/agents | `87b81e9` | `4bb47e9` |
| netresearch/agent-rules-skill | `9b67bf5` | `c8196b1` |

## Test plan
- [x] `go build -v ./...` clean
- [x] `go test -race -short ./...` — 210 passed in 21 packages