### PR TITLE
feat: experimental agent fact-check hooks, Opus 4.8 default, agent-rules v3.11.0

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
-  "model": "claude-opus-4-7[1m]",
+  "model": "claude-opus-4-8[1m]",
   "alwaysThinkingEnabled": true,
   "autoUpdatesChannel": "latest",
-  "effortLevel": "high",
+  "effortLevel": "max",
   "hooks": {
     "PostToolUse": [
       {

--- a/.claude/skills/agent-rules/SKILL.md
+++ b/.claude/skills/agent-rules/SKILL.md
@@ -5,7 +5,7 @@ license: "(MIT AND CC-BY-SA-4.0). See LICENSE-MIT and LICENSE-CC-BY-SA-4.0"
 compatibility: "Requires bash 4.3+, jq 1.5+, git 2.0+."
 metadata:
   author: Netresearch DTT GmbH
-  version: "3.7.0"
+  version: "3.11.0"
   repository: https://github.com/netresearch/agent-rules-skill
 allowed-tools: Bash(git:*) Bash(jq:*) Bash(grep:*) Bash(find:*) Bash(bash:*) Read Glob Grep
 ---
@@ -66,6 +66,8 @@ Use `--update` to preserve human-curated content outside `<!-- GENERATED -->` ma
 | [`output-structure.md`](references/output-structure.md) | Root/scoped sections |
 | [`git-hooks-setup.md`](references/git-hooks-setup.md) | Hook framework detection and setup |
 | [`examples/`](references/examples/) | Complete examples |
+| [`ai-contribution-guidelines.md`](references/ai-contribution-guidelines.md) | "3 Cs" framework for AI contributions (Comprehension, Context, Continuity) |
+| [`directory-coverage.md`](references/directory-coverage.md) | Full coverage rationale for scoped AGENTS.md files |
 
 ## Templates
 
@@ -74,3 +76,8 @@ Root: `assets/root-thin.md` (default), `root-verbose.md`. Scoped: `assets/scoped
 ## Supported Projects
 
 Go, PHP (Composer/Laravel/Symfony/TYPO3/Oro), TypeScript (React/Next/Vue/Node), Python (pip/poetry/ruff/mypy), Skill repos, Hybrid (multi-stack with auto-scoping).
+
+## See Also
+
+- [`agent-harness-skill`](https://github.com/netresearch/agent-harness-skill) — broader agent-readiness harness (CI verification, enforcement). Invokes this skill when AGENTS.md is missing.
+- [`skill-repo-skill`](https://github.com/netresearch/skill-repo-skill) — skill-repo structure (plugin.json, split licensing, release workflows).

--- a/.claude/skills/agent-rules/assets/root-thin.md
+++ b/.claude/skills/agent-rules/assets/root-thin.md
@@ -22,11 +22,16 @@
 
 > If commands fail, verify against Makefile/package.json/composer.json or ask user to update.
 
+## Response Style
+- Answer first, elaborate only if needed. No sycophantic openers ("Great question!", "Absolutely!").
+- For yes/no or status questions, lead with the answer.
+- Skip preamble. Match response length to task complexity.
+
 ## Workflow
 1. **Before coding**: Read nearest `AGENTS.md` + check Golden Samples for the area you're touching
 2. **After each change**: Run the smallest relevant check (lint → typecheck → single test)
 3. **Before committing**: Run full test suite if changes affect >2 files or touch shared code
-4. **Before claiming done**: Run verification and **show output as evidence** — never say "try again" or "should work now" without proof
+4. **Before claiming done**: Run verification and **show output as evidence** — never say "try again", "should work now", "tested", "verified", or "all green" without pasted command output in the same turn
 
 ## File Map
 <!-- AGENTS-GENERATED:START filemap -->
@@ -78,8 +83,11 @@
 - Run pre-commit checks before committing
 - Add tests for new code paths
 - Use conventional commit format: `type(scope): subject`
-- **Show test output as evidence before claiming work is complete** — never say "try again" or "should work now" without proof
+- Use **atomic commits** (one logical change per commit); preserve signatures, keep bisection useful
+- **Show test output as evidence before claiming work is complete** — never say "try again", "should work now", "tested", "verified", or "all green" without pasted command output
+- Before any edit, verify `pwd` resolves inside the intended repo worktree — not `.bare/`, not `~/.claude/skills/…`, not `~/.claude/plugins/cache/…` (those are read-only caches that get clobbered on update)
 - For upstream dependency fixes: run **full** test suite, not just affected tests
+- Force-push only with `--force-with-lease`
 {{LANGUAGE_CONVENTIONS}}
 
 ### Ask First
@@ -88,12 +96,18 @@
 - Changing public API signatures
 - Running full e2e test suites
 - Repo-wide refactoring or rewrites
+- Operations that touch >3 repos (produce a dry-run plan first)
 
 ### Never Do
 - Commit secrets, credentials, or sensitive data
 - Modify vendor/, node_modules/, or generated files
-- Push directly to main/master branch
+- Push directly to main/master branch — open a PR
+- Merge a PR before all review threads are resolved
+- Squash commits during merge or rebase unless the user explicitly asked
+- Edit installed skill/plugin cache paths (`~/.claude/skills/`, `~/.claude/plugins/cache/`, `**/.bare/**`) — always the source worktree
+- Reply to review comments with bare "Addressed" or "Fixed" — cite the resolving commit SHA
 - Delete migration files or schema changes
+- Use `secrets: inherit` in reusable GitHub Actions workflows (pass secrets explicitly)
 {{LANGUAGE_SPECIFIC_NEVER}}
 
 ## Contributing (for AI agents)

--- a/.claude/skills/agent-rules/assets/root-verbose.md
+++ b/.claude/skills/agent-rules/assets/root-verbose.md
@@ -14,9 +14,15 @@
 **Type**: {{PROJECT_TYPE}}
 <!-- AGENTS-GENERATED:END project-overview -->
 
+## Response Style
+- Answer first, elaborate only if needed. No sycophantic openers ("Great question!", "Absolutely!").
+- Lead with the answer for yes/no or status questions. Skip preamble.
+- Match response length to task complexity.
+
 ## Global Rules
 - Keep PRs small (~≤300 net LOC)
 - Conventional Commits: `type(scope): subject`
+- Atomic commits (one logical change per commit) — never squash unless explicitly asked
 {{LANGUAGE_CONVENTIONS}}
 
 ## Boundaries
@@ -27,8 +33,10 @@
 - Use conventional commit format: `type(scope): subject`
 - Keep dependencies updated
 - Validate all user inputs
-- **Show test output as evidence before claiming work is complete** — never say "try again" or "should work now" without proof
+- **Show test output as evidence before claiming work is complete** — never say "try again", "should work now", "tested", "verified", or "all green" without pasted command output in the same turn
+- Before any edit, verify `pwd` resolves inside the intended repo worktree — not `.bare/`, not `~/.claude/skills/…`, not `~/.claude/plugins/cache/…` (those are read-only caches that get clobbered on update)
 - For upstream dependency fixes: run **full** test suite, not just affected tests
+- Force-push only with `--force-with-lease`
 
 ### Ask First
 - Adding new dependencies
@@ -38,14 +46,20 @@
 - Repo-wide refactoring or rewrites
 - Modifying security-sensitive code
 - Changing database schemas
+- Any operation that touches >3 repos — produce a dry-run plan first
 
 ### Never Do
 - Commit secrets, credentials, API keys, or PII
 - Modify vendor/, node_modules/, or generated files
-- Push directly to main/master branch
+- Push directly to main/master branch — open a PR
+- Merge a PR before all review threads are resolved
+- Squash commits during merge/rebase unless the user explicitly asked
+- Edit installed skill/plugin cache paths (`~/.claude/skills/`, `~/.claude/plugins/cache/`, `**/.bare/**`)
+- Reply to review comments with bare "Addressed" or "Fixed" — cite the resolving commit SHA
 - Delete migration files or schema changes
 - Disable security features or linting rules
 - Hardcode environment-specific values
+- Use `secrets: inherit` in reusable GitHub Actions workflows (pass secrets explicitly)
 {{LANGUAGE_SPECIFIC_NEVER}}
 
 <!-- AGENTS-GENERATED:START module-boundaries -->
@@ -65,7 +79,7 @@
 1. **Before coding**: Read nearest `AGENTS.md` + check Golden Samples for the area you're touching
 2. **After each change**: Run the smallest relevant check (lint → typecheck → single test)
 3. **Before committing**: Run full test suite if changes affect >2 files or touch shared code
-4. **Before claiming done**: Run verification and **show output as evidence** — never say "try again" or "should work now" without proof
+4. **Before claiming done**: Run verification and **show output as evidence** — never say "try again", "should work now", "tested", or "verified" without pasted command output
 
 ## Pre-commit Checks
 > Source: {{COMMAND_SOURCE}} — CI-sourced commands are most reliable

--- a/.claude/skills/agent-rules/checkpoints.yaml
+++ b/.claude/skills/agent-rules/checkpoints.yaml
@@ -91,9 +91,9 @@ mechanical:
   - id: AG-13
     type: regex
     target: AGENTS.md
-    pattern: "^#+ (Commands|Commands \\(verified)"
+    pattern: '^#+ Commands( \(verified[^)]*\))?'
     severity: warning
-    desc: "AGENTS.md should have Commands section with verification status"
+    desc: "AGENTS.md should have Commands section (optionally with '(verified)' or '(verified DATE)' suffix for trust scoring)"
 
   - id: AG-14
     type: regex

--- a/.claude/skills/agent-rules/references/examples/fastapi-app/src/main.py
+++ b/.claude/skills/agent-rules/references/examples/fastapi-app/src/main.py
@@ -30,10 +30,12 @@ def create_app() -> FastAPI:
         lifespan=lifespan,
     )
 
-    # CORS middleware
+    # CORS middleware — wildcard origins here are intentional for this
+    # fixture example only; real deployments must set concrete origins
+    # from settings (e.g. settings.cors_allowed_origins).
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],
+        allow_origins=["*"],  # nosemgrep: python.fastapi.security.wildcard-cors.wildcard-cors
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],

--- a/.claude/skills/agent-rules/references/examples/go-api-with-react-admin/admin/package.json
+++ b/.claude/skills/agent-rules/references/examples/go-api-with-react-admin/admin/package.json
@@ -12,7 +12,7 @@
         "react-dom": "^18.2.0"
     },
     "devDependencies": {
-        "vite": "^5.0.0",
+        "vite": "^8.0.8",
         "vitest": "^1.0.0",
         "eslint": "^8.56.0",
         "typescript": "^5.3.0"

--- a/.claude/skills/agent-rules/references/examples/go-with-internal-web-tsx/internal/web/package.json
+++ b/.claude/skills/agent-rules/references/examples/go-with-internal-web-tsx/internal/web/package.json
@@ -11,7 +11,7 @@
         "react-dom": "^18.2.0"
     },
     "devDependencies": {
-        "vite": "^5.0.0",
+        "vite": "^8.0.8",
         "vitest": "^1.0.0"
     }
 }

--- a/.claude/skills/agent-rules/references/examples/go-with-internal-web-tsx/package.json
+++ b/.claude/skills/agent-rules/references/examples/go-with-internal-web-tsx/package.json
@@ -6,6 +6,7 @@
     },
     "devDependencies": {
         "react": "^18.0.0",
-        "vite": "^5.0.0"
+        "vite": "^8.0.8",
+        "vitest": "^1.0.0"
     }
 }

--- a/.claude/skills/agent-rules/references/examples/php-with-frontend/package.json
+++ b/.claude/skills/agent-rules/references/examples/php-with-frontend/package.json
@@ -7,8 +7,9 @@
         "test": "vitest run"
     },
     "devDependencies": {
+        "eslint": "^8.56.0",
         "react": "^18.0.0",
-        "vite": "^5.0.0",
+        "vite": "^8.0.8",
         "vitest": "^1.0.0"
     }
 }

--- a/.claude/skills/agent-rules/references/examples/php-with-frontend/web/package.json
+++ b/.claude/skills/agent-rules/references/examples/php-with-frontend/web/package.json
@@ -17,9 +17,10 @@
   },
   "devDependencies": {
     "@types/react": "^18.2.0",
+    "eslint": "^8.56.0",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.3.0",
-    "vite": "^5.0.0",
+    "vite": "^8.0.8",
     "vitest": "^1.0.0"
   }
 }

--- a/.claude/skills/agent-rules/references/feedback-memory-schema.md
+++ b/.claude/skills/agent-rules/references/feedback-memory-schema.md
@@ -1,0 +1,135 @@
+# Feedback Memory Schema
+
+Canonical format for **approved session learnings** materialized as project-rule or user-memory files. This schema is the contract between `retro-skill` (which writes these files) and `agent-rules-skill` (which manages how they integrate with AGENTS.md and project documentation).
+
+## When this schema applies
+
+| Destination | Path |
+|---|---|
+| **user-memory** (personal preference across projects) | `~/.claude/projects/<project-dir-slug>/memory/feedback_<slug>.md` |
+| **project-rule** (project-specific convention) | `<project>/docs/feedback/feedback_<slug>.md` |
+
+### Variable definitions
+
+| Variable | Meaning | Example |
+|---|---|---|
+| `<project-dir-slug>` | Claude Code's encoding of the absolute working directory for user-memory. Slashes are replaced with `-`. | `/home/sme/p` → `-home-sme-p` |
+| `<slug>` | kebab-case filename slug for *this specific learning* | `merge-strategy`, `preserve-commit-signing` |
+
+`<project-dir-slug>` and `<slug>` are distinct. `retro-skill` MUST compute `<project-dir-slug>` deterministically from the absolute working directory at the time of materialization (not from any frontmatter field).
+
+For user-memory **global** scope (not tied to a single project): place under whatever project-dir-slug Claude Code uses for global memory; consult `~/.claude/projects/` for the convention in use.
+
+## Schema
+
+```markdown
+---
+name: <human-readable title; may be free prose>
+description: "<one-line summary; used for relevance scoring across sessions>"
+type: feedback
+originSessionId: <session-id-from-jsonl-filename>
+---
+**Why:** <1-2 paragraphs explaining the friction and root cause>
+
+**How to apply:** <1-2 paragraphs describing how the assistant should behave next time>
+```
+
+### Field semantics
+
+| Field | Required | Notes |
+|---|---|---|
+| `name` | yes | Human-readable title for the learning. May be a free-form sentence (e.g. `"Preserve commit signing on rewrite operations"`) or a short slug (e.g. `"merge strategy"`). **Not necessarily kebab-case** — the canonical examples use both natural language and slugs. The **filename** uses an independent kebab-case slug (see "Filename slug" below). |
+| `description` | yes | One-line summary, ≤200 chars. Used by retro-skill to score relevance against new friction. **MUST be double-quoted** when it contains any of `: # [ ] { } , & * ! \| > ' " % @` or a leading whitespace, or it may break YAML parsing. Safer rule: quote unconditionally. |
+| `type` | yes | always `feedback` (distinguishes from other memory types). |
+| `originSessionId` | recommended, not required | Session ID where the friction was first observed (audit trail). If absent, the file is still valid but loses traceability. |
+| `**Why:**` body section | yes | Start of line, exact form `**Why:** ` (with trailing space). Without this, the file rots — readers can't judge if it still applies. |
+| `**How to apply:**` body section | yes | Start of line, exact form `**How to apply:** `. Vague rules don't change behavior. |
+
+### Filename slug (independent from `name`)
+
+The `<slug>` in the filename `feedback_<slug>.md` is **separately chosen** by retro-skill, kebab-case, descriptive of the learning topic. It is NOT required to match `frontmatter.name`.
+
+Canonical examples demonstrate the freedom: file `feedback_skill-sources.md` has `name: "skill source vs cache"`; file `feedback_no-version-bumps-in-feature-prs.md` has `name: "No version bumps in feature PRs"`.
+
+## Project-rule placement
+
+When `retro-skill` materializes a `project-rule` destination:
+
+1. **Write file:** `<project>/docs/feedback/feedback_<slug>.md` (create `docs/feedback/` if missing).
+2. **Add AGENTS.md index entry** under a `## Approved learnings` section:
+
+```markdown
+## Approved learnings
+
+- [feedback_<slug>.md](docs/feedback/feedback_<slug>.md) — <one-line summary from frontmatter description>
+```
+
+The index entry is a single line; the full prose lives in the linked file.
+
+### Section position in AGENTS.md
+
+`## Approved learnings` should be placed **after `## Key Decisions` and before `## Boundaries`** in the `root-thin.md` template's section order. **Place it outside `<!-- AGENTS-GENERATED:START ... -->` markers** so `generate-agents.sh --update` preserves it — this section is managed by retro-skill, not by the generator.
+
+If the project's AGENTS.md is at or near the 150-line cap (the harness AH-02 threshold), prune older inactive learnings or move to a scoped `AGENTS.md` rather than letting the index grow unbounded.
+
+## User-memory placement
+
+When `retro-skill` materializes a `user-memory` destination:
+
+1. **Compute path:** `~/.claude/projects/<project-dir-slug>/memory/feedback_<slug>.md` for project-scoped learnings, OR the global-scope path (consult `~/.claude/projects/`).
+2. **Write file** using the schema above.
+3. **Add MEMORY.md index entry** under the existing flat `## Topic Files` section (no sub-sections):
+
+```markdown
+- [feedback_<slug>.md](feedback_<slug>.md) — <one-line summary>
+```
+
+Do not create a separate `## Feedback` heading — MEMORY.md uses a single flat list.
+
+## Why this schema (rationale)
+
+- **Frontmatter** is machine-readable and tool-discoverable.
+- **`description`** lets retro-skill detect duplicates and rank relevance.
+- **`Why:` + `How to apply:`** structure forces meaningful content; vague file = vague rule.
+- **`originSessionId`** allows tracing back to the friction; supports audit and deprecation.
+
+## Validation
+
+A valid feedback file has:
+
+- YAML frontmatter present and parseable by PyYAML / yq.
+- Required fields populated (non-empty): `name`, `description`, `type`.
+- `description` is double-quoted (or doesn't contain YAML-special characters).
+- Both `**Why:** ` and `**How to apply:** ` body markers present at start-of-line.
+- File path matches `feedback_<slug>.md` where `<slug>` is kebab-case (independent of frontmatter `name`).
+
+`originSessionId` is recommended but its absence does NOT invalidate the file.
+
+Optional `scripts/verify-feedback-memory.sh` (not yet implemented; tracked as TODO) can enforce this in CI.
+
+## Validation gap (current state)
+
+`references/verification-guide.md` does **not** yet include a row for feedback files. Adding the check is tracked separately. retro-skill's PR-time validation of materialized files is the de-facto enforcement until the agent-rules-skill validator catches up.
+
+## Examples in the wild
+
+The user's own memory at `~/.claude/projects/-home-sme-p/memory/` contains **9 files** following this schema:
+
+- `feedback_dup-repo-verification.md`
+- `feedback_merge-strategy.md`
+- `feedback_merge-vs-rollout.md`
+- `feedback_no-version-bumps-in-feature-prs.md`
+- `feedback_obsolete-docs-prefer-delete.md`
+- `feedback_preserve-commit-signing.md`
+- `feedback_skill-iteration-cadence.md`
+- `feedback_skill-sources.md`
+- `feedback_subagent-default.md`
+
+Some include an extended `metadata:` block (e.g. `feedback_merge-vs-rollout.md` has `metadata: { node_type: memory, type: feedback }`); that variant is tolerated, not required.
+
+## See also
+
+- `retro-skill/references/destination-taxonomy.md` — Where this schema applies (in retro-skill repo)
+- `retro-skill/references/patch-workflow.md` — How retro-skill writes these (in retro-skill repo)
+- `references/output-structure.md` — How AGENTS.md indexes feedback files
+- `references/verification-guide.md` — How to validate the resulting AGENTS.md

--- a/.claude/skills/agent-rules/references/output-structure.md
+++ b/.claude/skills/agent-rules/references/output-structure.md
@@ -33,6 +33,15 @@ Additional recommended sections:
 - Good vs Bad examples
 - When stuck
 - House Rules (for scoped overrides)
+- **Approved learnings** — index entries linking to `docs/feedback/feedback_<slug>.md` (one line per learning, see [feedback-memory-schema.md](feedback-memory-schema.md))
+
+### AGENTS.md is an index, not a rule dump
+
+When session learnings are approved (via `/retro` or similar), the **prose lives in `docs/feedback/feedback_<slug>.md`** following the [feedback memory schema](feedback-memory-schema.md). AGENTS.md only carries a one-line link per learning under `## Approved learnings`. This keeps AGENTS.md compact (the agent-harness conformance rule) while preserving full audit trail in `docs/feedback/`.
+
+Place `## Approved learnings` **after `## Key Decisions` and before `## Boundaries`** in the section order, and put it **outside** any `<!-- AGENTS-GENERATED:START ... -->` markers — this section is managed by retro-skill, not by `generate-agents.sh`, so it must survive `--update` runs.
+
+If the approved-learnings index would push AGENTS.md over the harness 150-line cap (`AH-02`), prune inactive entries or move to a scoped `AGENTS.md` rather than letting the index grow unbounded.
 
 ## When to Customize vs Auto-Generate
 

--- a/.claude/skills/agent-rules/scripts/detect-scopes.sh
+++ b/.claude/skills/agent-rules/scripts/detect-scopes.sh
@@ -319,5 +319,12 @@ fi
 if [ ${#scopes[@]} -eq 0 ]; then
     echo '{"scopes": []}'
 else
-    echo "{\"scopes\": [$(IFS=,; echo "${scopes[*]}")]}"
+    # Join scopes with commas via explicit loop — avoids IFS= entirely
+    # (the opengrep bash.lang.security.ifs-tampering rule flags any
+    # IFS= assignment, even inside subshells).
+    joined="${scopes[0]}"
+    for ((i=1; i<${#scopes[@]}; i++)); do
+        joined+=",${scopes[i]}"
+    done
+    echo "{\"scopes\": [$joined]}"
 fi

--- a/.claude/skills/agent-rules/scripts/generate-agents.sh
+++ b/.claude/skills/agent-rules/scripts/generate-agents.sh
@@ -218,8 +218,10 @@ detect_css_approach() {
         [ -f "$config_root/tsconfig.json" ] && approaches+=("CSS Modules")
     fi
 
-    # Join approaches with comma
-    local IFS=', '
+    # Join approaches with comma. `local IFS` is function-scoped and does
+    # not tamper with the caller's IFS — safe under strict SC2030/SC2031
+    # semantics. Suppress opengrep's false positive on the `IFS=` pattern.
+    local IFS=', '  # nosemgrep: bash.lang.security.ifs-tampering.ifs-tampering
     echo "${approaches[*]}"
 }
 

--- a/cmd/yaah/main.go
+++ b/cmd/yaah/main.go
@@ -34,8 +34,20 @@ var (
 
 // newHarness creates the default Harness with all built-in handlers.
 // In a consumer repo, you'd replace this with your own setup.
+//
+// Experimental opt-ins via environment:
+//
+//	YAAH_EXPERIMENTAL_FACT_CHECK=1
+//	    Install agent-type Stop/SubagentStop hooks that spawn a Sonnet
+//	    subagent with Read/Grep/Glob/WebFetch to verify cited resources
+//	    in the final message. Agent hooks are marked experimental upstream;
+//	    expect added latency and cost.
 func newHarness() *harnesspkg.Harness {
-	return harnesspkg.NewWithDefaults(harnesspkg.AllDefaults())
+	opts := harnesspkg.AllDefaults()
+	if os.Getenv("YAAH_EXPERIMENTAL_FACT_CHECK") != "" {
+		opts.EnableFactCheckHooks = true
+	}
+	return harnesspkg.NewWithDefaults(opts)
 }
 
 func main() {

--- a/docs/components.md
+++ b/docs/components.md
@@ -76,6 +76,20 @@ Writes session start/stop events with timestamps to a log file.
 h.Hooks().Register(handlers.NewSessionLogger("/var/log/claude-sessions"))
 ```
 
+### FactCheck (experimental)
+
+Installs `agent`-type `Stop` and `SubagentStop` hooks that spawn a Sonnet subagent with `Read`/`Grep`/`Glob`/`WebFetch` to verify cited resources in the assistant's final message (file paths exist, function names resolve, URLs return successfully). When a citation cannot be confirmed the runtime surfaces the failure as feedback on the next turn.
+
+```go
+opts := harness.AllDefaults()
+opts.EnableFactCheckHooks = true   // experimental — agent hooks are marked experimental upstream
+h := harness.NewWithDefaults(opts)
+```
+
+For CLI users, set `YAAH_EXPERIMENTAL_FACT_CHECK=1` and re-run `yaah generate`. Default state installs no fact-check hooks; users opt in explicitly. Higher latency and cost than command/prompt hooks — each Stop spawns a tool-using subagent.
+
+Configure the hook directly without enabling the default via `Harness.AddHookRule` for full control over model, timeout, and prompt phrasing.
+
 ### Middleware chains
 
 Chain multiple handlers into a sequential pipeline. Each link receives the previous link's result, enabling composed workflows like "scan for secrets, then suggest remediation if blocked."

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -88,7 +88,7 @@ Run it with `go run ./cmd/your-setup/` whenever you change your config.
 
 | Group                    | Fields                                                                                                                                                                       |
 | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Core                     | `model`, `alwaysThinkingEnabled`, `autoUpdatesChannel`, `effortLevel`, `statusLine`, `env`, `teammateMode`                                                                   |
+| Core                     | `model`, `alwaysThinkingEnabled`, `autoUpdatesChannel`, `effortLevel` (`low`/`medium`/`high`/`xhigh`/`max`), `statusLine`, `env`, `teammateMode`                             |
 | Model and performance    | `availableModels`, `fastMode`, `fastModePerSessionOptIn`                                                                                                                     |
 | Permissions and security | `permissions`, `sandbox`, `allowManagedPermissionRulesOnly`                                                                                                                  |
 | Hooks and automation     | `disableAllHooks`, `allowManagedHooksOnly`                                                                                                                                   |
@@ -128,6 +128,12 @@ yaah session show <id>             # Show full details for a session
 yaah session clean                 # Remove sessions older than 7 days
 yaah version                       # Print version, commit, and build date
 ```
+
+### Experimental opt-ins
+
+| Environment variable             | Effect                                                                                                                                                          |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `YAAH_EXPERIMENTAL_FACT_CHECK=1` | Install `agent`-type `Stop`/`SubagentStop` hooks that spawn a Sonnet subagent with `Read`/`Grep`/`Glob`/`WebFetch` to verify cited resources in the final message. |
 
 ## Workflow
 

--- a/pkg/harness/defaults.go
+++ b/pkg/harness/defaults.go
@@ -26,7 +26,12 @@ type DefaultOptions struct {
 	EnableSecretScanner     bool
 	EnableSecretRemediation bool
 	EnableSessionLogger     bool
-	LintProfiles            []handlers.Profile
+	// EnableFactCheckHooks installs agent-type Stop/SubagentStop hooks that
+	// spawn a Sonnet subagent with Read/Grep/Glob/WebFetch to verify cited
+	// resources in the final message. EXPERIMENTAL — Claude Code marks "agent"
+	// hooks as experimental and the contract may change.
+	EnableFactCheckHooks bool
+	LintProfiles         []handlers.Profile
 
 	// Providers (MCP)
 	EnableContext7  bool
@@ -287,12 +292,43 @@ func AllDefaults() DefaultOptions {
 		EnableAgencyAPITester:              true,
 		EnableAgencyPerformanceBenchmarker: true,
 		Settings: &schema.Settings{
-			Model:                 "claude-opus-4-7[1m]",
+			Model:                 "claude-opus-4-8[1m]",
 			AlwaysThinkingEnabled: &thinking,
-			EffortLevel:           "high",
+			EffortLevel:           "max",
 			AutoUpdatesChannel:    "latest",
 		},
 	}
+}
+
+// Fact-check prompts installed on Stop/SubagentStop hooks when
+// EnableFactCheckHooks is set. A FAIL verdict blocks the stop and forces
+// Claude (or the subagent) to revise.
+// Agent-type hooks spawn a subagent with Read/Grep/Glob/WebFetch tools to
+// verify cited resources by inspection rather than judging plausibility from
+// training data. Phrased as a declarative condition the agent must confirm.
+// See: https://code.claude.com/docs/en/hooks
+const factCheckAgentCondition = "Every file path, function or symbol name, command-line flag, " +
+	"and URL cited in the assistant's final message can be confirmed to exist by using the " +
+	"available tools: use Read to open cited file paths, Grep/Glob to confirm cited symbols " +
+	"and flags appear in the codebase, and WebFetch to verify cited URLs return successfully. " +
+	"Treat opinions, instructional guidance, hedged language, and meta-commentary as compliant. " +
+	"Only fail when a concrete citation cannot be confirmed by the tools."
+
+// registerFactCheckHooks installs agent-type Stop and SubagentStop hooks that
+// spawn a tool-using subagent to verify cited resources. EXPERIMENTAL —
+// "agent" hooks are marked experimental upstream; latency and cost are higher
+// than command-only hooks.
+func registerFactCheckHooks(p *Harness) {
+	rule := schema.HookRule{
+		Hooks: []schema.HookHandler{{
+			Type:    schema.HookTypeAgent,
+			Prompt:  factCheckAgentCondition,
+			Model:   "claude-sonnet-4-6",
+			Timeout: 60,
+		}},
+	}
+	p.AddHookRule(schema.HookStop, rule)
+	p.AddHookRule(schema.HookSubagentStop, rule)
 }
 
 // NewWithDefaults creates a Harness pre-loaded with built-in components.
@@ -330,6 +366,9 @@ func NewWithDefaults(opts DefaultOptions) *Harness {
 	}
 	if opts.EnableSessionLogger {
 		p.Hooks().Register(handlers.NewSessionLogger(""))
+	}
+	if opts.EnableFactCheckHooks {
+		registerFactCheckHooks(p)
 	}
 
 	// Providers.
@@ -644,7 +683,7 @@ func NewWithDefaults(opts DefaultOptions) *Harness {
 	if opts.EnableAgentRules {
 		p.Skills().Register(skills.NewRemoteSkill(
 			"agent-rules", "Generate and maintain AGENTS.md files following the agents.md convention",
-			"github.com/netresearch/agent-rules-skill@c8196b1bb9821ca3950639263af6d44cadf6caa1", "skills/agent-rules/SKILL.md",
+			"github.com/netresearch/agent-rules-skill@1d739213f18eca7af0f081a36bd02f10c7bc2b7c", "skills/agent-rules/SKILL.md",
 		))
 	}
 
@@ -890,6 +929,9 @@ func NewFromCatalog(opts DefaultOptions) *Harness {
 	}
 	if opts.EnableSessionLogger {
 		p.Hooks().Register(handlers.NewSessionLogger(""))
+	}
+	if opts.EnableFactCheckHooks {
+		registerFactCheckHooks(p)
 	}
 
 	// Providers — same as NewWithDefaults.

--- a/pkg/harness/harness.go
+++ b/pkg/harness/harness.go
@@ -35,6 +35,7 @@ type Harness struct {
 	plugins      *plugins.Registry
 	settings     *schema.Settings
 	sessionStore *session.Store
+	extraHooks   schema.HooksConfig
 }
 
 // New creates a new Harness with empty registries.
@@ -77,6 +78,17 @@ func (p *Harness) SessionStore() *session.Store { return p.sessionStore }
 
 // SetSettings sets the base Claude Code settings.
 func (p *Harness) SetSettings(s *schema.Settings) { p.settings = s }
+
+// AddHookRule appends a HookRule for the given event that is not backed by a
+// Go handler — used for prompt/agent/http hooks that the Claude Code runtime
+// executes directly (e.g. fact-check hooks). Rules added here are merged into
+// the generated settings.json alongside handler-driven command hooks.
+func (p *Harness) AddHookRule(event schema.HookEvent, rule schema.HookRule) {
+	if p.extraHooks == nil {
+		p.extraHooks = make(schema.HooksConfig)
+	}
+	p.extraHooks[event] = append(p.extraHooks[event], rule)
+}
 
 // HandleHookEvent dispatches a hook event through all enlisted handlers.
 // It also records the event in the session store when a session ID is present.
@@ -227,6 +239,18 @@ func (p *Harness) GenerateConfig() *schema.HarnessConfig {
 					}},
 				})
 			}
+		}
+	}
+
+	// Extra hooks: prompt/agent/http rules not backed by Go handlers
+	// (e.g. fact-check Stop/SubagentStop hooks executed directly by the
+	// Claude Code runtime).
+	if len(p.extraHooks) > 0 {
+		if cfg.Hooks == nil {
+			cfg.Hooks = make(schema.HooksConfig)
+		}
+		for event, rules := range p.extraHooks {
+			cfg.Hooks[event] = append(cfg.Hooks[event], rules...)
 		}
 	}
 

--- a/pkg/schema/settings.go
+++ b/pkg/schema/settings.go
@@ -26,7 +26,7 @@ type Settings struct {
 	Model                 string            `json:"model,omitempty"                        jsonschema:"description=Default model (opus/sonnet/haiku)"`
 	AlwaysThinkingEnabled *bool             `json:"alwaysThinkingEnabled,omitempty"        jsonschema:"description=Enable extended thinking"`
 	AutoUpdatesChannel    string            `json:"autoUpdatesChannel,omitempty"           jsonschema:"description=Update channel (latest/stable)"`
-	EffortLevel           string            `json:"effortLevel,omitempty"                  jsonschema:"description=Reasoning effort (low/medium/high),enum=low,enum=medium,enum=high"`
+	EffortLevel           string            `json:"effortLevel,omitempty"                  jsonschema:"description=Reasoning effort (low/medium/high/xhigh/max),enum=low,enum=medium,enum=high,enum=xhigh,enum=max"`
 	StatusLine            *StatusLine       `json:"statusLine,omitempty"                   jsonschema:"description=Status line configuration"`
 	Env                   map[string]string `json:"env,omitempty"                          jsonschema:"description=Environment variables for Claude Code"`
 	TeammateMode          string            `json:"teammateMode,omitempty"                 jsonschema:"description=Agent team mode (tmux/etc)"`


### PR DESCRIPTION
## Summary

- Add **experimental agent-type fact-check hooks** for `Stop`/`SubagentStop`. When enabled, each turn's final message is verified by a Sonnet 4.6 subagent with `Read`/`Grep`/`Glob`/`WebFetch` — citations to files, symbols, and URLs are checked against the actual sources instead of judged from training-data plausibility. Off by default; opt in via `YAAH_EXPERIMENTAL_FACT_CHECK=1` and re-run `yaah generate`. Marked experimental because Claude Code's `agent`-type hooks are themselves marked experimental upstream.
- Add `Harness.AddHookRule(event, rule)` so registries can emit non-handler hook entries (`prompt`/`agent`/`http`) into the generated `settings.json` alongside command-type Go handlers. Merged into `cfg.Hooks` inside `GenerateConfig`.
- Widen `Settings.EffortLevel` jsonschema enum to `low|medium|high|xhigh|max` (was `low|medium|high`) to match the official Claude Code settings schema. Default bumped from `high` → `max`.
- Bump default model from `claude-opus-4-7[1m]` → `claude-opus-4-8[1m]` (Opus 4.8 1M context).
- Bump `netresearch/agent-rules-skill` from `c8196b1` (v3.7.0) to `1d73921` (v3.11.0), refresh the generated `.claude/skills/agent-rules/` tree (+135-line `feedback-memory-schema.md` reference, CI/script tweaks).

Other pinned remote sources (`pulumi/agent-skills`, `dirien/claude-skills`, `jeffallan/claude-skills`, `msitarzewski/agency-agents`, `rshade/agent-skills`) verified up-to-date — no SHA bumps needed.

## Test plan

- [x] `go test -race -short ./...` — 210 tests pass across 21 packages
- [x] `go build -v ./...` — clean
- [x] `yaah generate --agent claude` with `YAAH_EXPERIMENTAL_FACT_CHECK` unset emits **no** fact-check hooks (`Stop` has only the existing `command` entry, `SubagentStop` is absent)
- [x] `YAAH_EXPERIMENTAL_FACT_CHECK=1 yaah generate --agent claude` emits agent-type hooks (`Sonnet`, 60s timeout) on both `Stop` and `SubagentStop`
- [x] Manual fact-check exercise (in-session): the agent verifier correctly flagged a fabricated `os.YeetFile` claim
- [ ] Reviewer: confirm `effortLevel: "max"` is accepted by your local Claude Code build before merging — schema docs list it as valid, but verifying once on a real session is cheap insurance